### PR TITLE
impl&test color grouping functions

### DIFF
--- a/src/data/grouping/stickyColor.ts
+++ b/src/data/grouping/stickyColor.ts
@@ -1,0 +1,85 @@
+// A literal value that assigns a color to the background of the sticky note
+const data = [
+    {
+        fillColor: 'light_yellow',
+        hex: '#ffff00',
+        color: 'Light Yellow'
+    },
+    {
+        fillColor:'gray',
+        hex: '#f5f6f8',
+        color: 'Gray'
+    },
+    {
+        fillColor:'yellow',
+        hex: '#f5d128',
+        color: 'Yellow'
+    },
+    {
+        fillColor:'orange',
+        hex: '#ff9d48',
+        color: 'Orange'
+    },
+    {
+        fillColor:'light_green',
+        hex: '#d5f692',
+        color: 'Light Green'
+    },
+    {
+        fillColor:'green',
+        hex: '#c9df56',
+        color: 'Green'
+    },
+    {
+        fillColor:'dark_green',
+        hex: '#93d275',
+        color: 'Dark Green'
+    },
+    {
+        fillColor:'cyan',
+        hex: '#67c6c0',
+        color: 'Cyan'
+    },
+    {
+        fillColor:'light_pink',
+        hex: '#ffcee0',
+        color: 'Light Pink'
+    },
+    {
+        fillColor:'pink',
+        hex: '#ea94bb',
+        color: 'Pink'
+    },
+    {
+        fillColor:'violet',
+        hex: '#c6a2d2',
+        color: 'Violet'
+    },
+    {
+        fillColor:'red',
+        hex: '#f0939d',
+        color: 'Red'
+    },
+    {
+        fillColor:'light_blue',
+        hex: '#a6ccf5',
+        color: 'Light Blue'
+    },
+    {
+        fillColor:'blue',
+        hex: '#6cd8fa',
+        color: 'Blue'
+    },
+    {
+        fillColor:'dark_blue',
+        hex: '#9ea9ff',
+        color: 'Dark Blue'
+    },
+    {
+        fillColor:'black',
+        hex: '#000000',
+        color: 'Black'
+    }
+];
+
+export default data;

--- a/src/grouping.tsx
+++ b/src/grouping.tsx
@@ -87,13 +87,22 @@ function preprocessingByType(): void {
 }
 
 /**
- * Clusters board items by their type, considering groups and frames as predefined clusters.
+ * Initial clustering
+ * Clusters board items by group, frame, floating, considering groups and frames as predefined clusters.
  * Floating items are clustered based on proximity using clusterByDistance.
  */
 function clusterByType(): void {
-  // for frame, group: no ops, default to be one cluster
-  // for floating: need to go through clusterByDistance() one to get clusters
-}
+  items.forEach((item) => {
+    if (item.type === "frame") {
+      frameSet.add(item.id);
+    } else if (item.type === "group") {
+      groupSet.add(item.id);
+    } else {
+      // tbd for future implementation
+      floatingSet.add(item.id);
+    }
+  });
+};
 
 /**
  * Clusters items based on spatial proximity.

--- a/src/grouping.tsx
+++ b/src/grouping.tsx
@@ -3,6 +3,8 @@
 import { BoardNode } from "@mirohq/websdk-types";
 import { GetColorName } from "hex-color-to-color-name";
 
+import data from "./data/grouping/stickyColor";
+
 // ------------------------------------------------------------ Data Structure ----------------------------------------------------------
 
 // Global variable to make Miro items accessible throughout the file
@@ -14,7 +16,6 @@ let groupSet: Set<string> = new Set();
 let floatingSet: Set<string> = new Set();
 
 // Maps and Sets to organize items by their characteristics
-let colorMap:Map<string, Set<string>> = new Map(); // todo(hy) tbd
 let shapeMap: Map<string, Set<string>> = new Map();
 let stickyNoteSet: Set<string> = new Set();
 let cardSet: Set<string> = new Set();
@@ -106,20 +107,19 @@ function clusterByDistance(): string[][] {
 /**
  * Groups items within a cluster based on their color.
  * @param cluster An array of item IDs as strings.
- * @returns a map of color to a list of item IDs.
+ * @returns A map of color to a list of item IDs.
  */
 export function groupByColors(cluster: string[]):Map<string, Set<string>>{
   let colorMap: Map<string, Set<string>> = new Map();
   cluster.forEach((item) => {
-    const color = getColor(item, cluster);
+    const color = getColor(item, items);
     if (colorMap.has(color)) {
       colorMap.get(color)!.add(item);
     } else {
-      colorMap.set(color, new Set(item));
+      colorMap.set(color, new Set([item]));
     }
     return colorMap;
-  })
-
+  });
   return colorMap;
 }
 
@@ -150,20 +150,21 @@ function evaluateClusters(
 
 /**
  * Retrieves the color of an item by its ID.
+ * @param id the node's id string
+ * @param items container stores all the BoardNode objects.
  * @returns The color of the item as a string.
  */
-function getColor(id: string, items): string {
+export function getColor(id: string, items): string {
   const item = items.find((item) => item.id === id);
   let color;
   if (item.type === "card") {
     color = GetColorName(item.style.cardTheme);
   } else if (item.type === "shape") {
-    color =
-      item.style.fillColor !== "transparent"
+    color = item.style.fillColor !== "transparent"
         ? GetColorName(item.style.fillColor)
-        : GetColorName(item.style.borderColor);
+        : "Uncolored";
   } else if (item.type === "sticky_note") {
-    color = item.style.fillColor;
+    color = getStickyNoteColor(item.style.fillColor);
   } else if (item.type === "text") {
     color = GetColorName(item.style.color);
   } else {
@@ -194,6 +195,15 @@ export function getLocation(id: string, items): [number, number] {
 // For purpose of testing only, to be deleted
 export function add(a: number, b: number): number {
   return a + b;
+}
+
+// helper function for sticky note color
+export function getStickyNoteColor(color:string):string {
+  for (const item of data) {
+    if (item.fillColor === color) {
+      return item.color;
+    }
+  }
 }
 
 // ------------------------------------------------------------ OLD ------------------------------------------------------------

--- a/test/groupingColor.test.ts
+++ b/test/groupingColor.test.ts
@@ -1,9 +1,58 @@
-import { groupByColors } from '../src/grouping.tsx';
+import { getColor, getStickyNoteColor } from '../src/grouping';
+import { mockShape1, mockShape2, mockShape3 } from './mockBoardNodes';
+import { mockStickyNote1, mockStickyNote2 } from './mockBoardNodes';
 
-jest.mock('miro', () => {
-    return {
-        board: {
-        get: jest.fn().mockResolvedValue(mockItems1),
-        },
-    };
+// test groupByColor function
+// given we are declaring global variables in the actual code,
+// solution for testing is to mock the function logic within the test file
+function groupByColor(cluster: string[], items: any) {
+    let colorMap: Map<string, Set<string>> = new Map();
+    cluster.forEach((item) => {
+        const color = getColor(item, items);
+        if (colorMap.has(color)) {
+            colorMap.get(color)!.add(item);
+        } else {
+            colorMap.set(color, new Set([item]));
+        }
+        return colorMap;
+    });
+    return colorMap;
+}
+
+// Map(4) {
+//     'Lightning Yellow' => Set(2) { '3458764580516886289', '3458764580530425719' },
+//     'Uncolored' => Set(1) { '3458764580530425796' },
+//     'Light Yellow' => Set(1) { '3458764580516885999' },
+//     'Yellow' => Set(1) { '3458764580516886689' }
+//   }
+describe('groupByColor', () => {
+    it('should group items by color', () => {
+        const items = [mockShape1, mockShape2, mockShape3, mockStickyNote1, mockStickyNote2];
+        const cluster = [mockShape1.id, mockShape2.id, mockShape3.id, mockStickyNote1.id, mockStickyNote2.id];
+        const colorMap = groupByColor(cluster, items);
+        expect(colorMap.get('Lightning Yellow')!.size).toBe(2);
+        expect(colorMap.get('Uncolored')!.size).toBe(1);
+        expect(colorMap.get('Light Yellow')!.size).toBe(1);
+        expect(colorMap.get('Yellow')!.size).toBe(1);
+    });
+});
+
+// Test getColor function
+describe('getColor', () => {
+    it('should return the correct color of the item', () => {
+        const items = [mockShape1, mockShape2, mockShape3, mockStickyNote1, mockStickyNote2];
+        expect(getColor(mockShape1.id, items)).toBe('Lightning Yellow');
+        expect(getColor(mockShape2.id, items)).toBe('Lightning Yellow');
+        expect(getColor(mockShape3.id, items)).toBe('Uncolored');
+        expect(getColor(mockStickyNote1.id, items)).toBe('Light Yellow');
+        expect(getColor(mockStickyNote2.id, items)).toBe('Yellow');
+    });
+});
+
+// Test getStickyHex function
+describe('getStickyHex', () => {
+    it('should return the correct hex value of the sticky note color', () => {
+        expect(getStickyNoteColor(mockStickyNote1.style.fillColor)).toBe('Light Yellow');
+        expect(getStickyNoteColor(mockStickyNote2.style.fillColor)).toBe('Yellow');
+    });
 });

--- a/test/mockBoardNodes.ts
+++ b/test/mockBoardNodes.ts
@@ -1,59 +1,152 @@
 /* This file is a mock of the board nodes data structure. It is used to test the grouping functions. */
 
+// shape - round rec - content - fill - border
 export const mockShape1 = {
-    content: '<p>This is a star shape.</p>',
-    shape: 'star',
+    type: "shape",
+    content: "<p>this is content</p>",
+    shape: "round_rectangle",
     style: {
-        color: '#ff0000',
-        fillColor: '#ffff00',
-        fontFamily: 'arial',
-        fontSize: 14,
-        textAlign: 'center',
-        textAlignVertical: 'middle',
-        borderStyle: 'normal',
-        borderOpacity: 1.0,
-        borderColor: '#ff7400',
+        fillColor: "#fac710",
+        fontFamily: "open_sans",
+        fontSize: 28,
+        textAlign: "center",
+        textAlignVertical: "middle",
+        borderStyle: "normal",
+        borderOpacity: 1,
+        borderColor: "#1a1a1a",
         borderWidth: 2,
-        fillOpacity: 1.0,
+        fillOpacity: 1,
+        color: "#1a1a1a"
     },
-    x: 0,
-    y: 0,
-    width: 200,
-    height: 200,
+    id: "3458764580516886289",
+    parentId: null,
+    origin: "center",
+    relativeTo: "canvas_center",
+    createdAt: "2024-02-27T23:01:49.836Z",
+    createdBy: "3458764575728178245",
+    modifiedAt: "2024-02-28T04:32:06.939Z",
+    modifiedBy: "3458764575728178245",
+    connectorIds: [],
+    x: -2078.8002239449133,
+    y: 1259.070165330662,
+    width: 304,
+    height: 156,
+    rotation: 0
 };
 
+// shape - round rec - content - fill
 export const mockShape2 = {
-    content: '<p>This is a rectangle shape.</p>',
-    shape: 'rectangle',
+    type: "shape",
+    content: "<p>this is content</p>",
+    shape: "round_rectangle",
     style: {
-        color: '#00ff00',
-        fillColor: '#00ffff',
-        fontFamily: 'arial',
-        fontSize: 14,
-        textAlign: 'center',
-        textAlignVertical: 'middle',
-        borderStyle: 'normal',
-        borderOpacity: 1.0,
-        borderColor: '#0074ff',
+        fillColor: "#fac710",
+        fontFamily: "open_sans",
+        fontSize: 28,
+        textAlign: "center",
+        textAlignVertical: "middle",
+        borderStyle: "normal",
+        borderOpacity: 1,
+        borderColor: "transparent",
         borderWidth: 2,
-        fillOpacity: 1.0,
+        fillOpacity: 1,
+        color: "#1a1a1a"
     },
-    x: 100,
-    y: 100,
-    width: 200,
-    height: 200,
+    id: "3458764580530425719",
+    parentId: null,
+    origin: "center",
+    relativeTo: "canvas_center",
+    createdAt: "2024-02-28T03:56:21.459Z",
+    createdBy: "3458764575728178245",
+    modifiedAt: "2024-02-28T03:59:18.448Z",
+    modifiedBy: "3458764575728178245",
+    connectorIds: [],
+    x: -1724.8002239449133,
+    y: 1259.070165330662,
+    width: 304,
+    height: 156,
+    rotation: 0
 };
 
-export const mockStickyNote1 =
-    {
-        content: '<p>This is a sticky note. It looks just like the actual paper one.</p>',
-        style: {
-          fillColor: 'light_yellow', // Default value: light yellow
-          textAlign: 'center', // Default alignment: center
-          textAlignVertical: 'middle', // Default alignment: middle
-        },
-        x: 0, // Default value: horizontal center of the board
-        y: 0, // Default value: vertical center of the board
-        shape: 'square',
-        width: 200, // Set either 'width', or 'height'
-      };
+export const mockShape3 = {
+    type: "shape",
+    content: "<p>this is content</p>",
+    shape: "round_rectangle",
+    style: {
+        fillColor: "transparent",
+        fontFamily: "open_sans",
+        fontSize: 28,
+        textAlign: "center",
+        textAlignVertical: "middle",
+        borderStyle: "normal",
+        borderOpacity: 1,
+        borderColor: "#1a1a1a",
+        borderWidth: 2,
+        fillOpacity: 1,
+        color: "#1a1a1a"
+    },
+    id: "3458764580530425796",
+    parentId: null,
+    origin: "center",
+    relativeTo: "canvas_center",
+    createdAt: "2024-02-28T03:56:28.141Z",
+    createdBy: "3458764575728178245",
+    modifiedAt: "2024-02-28T04:32:08.875Z",
+    modifiedBy: "3458764575728178245",
+    connectorIds: [],
+    x: -1366.8002239449133,
+    y: 1259.070165330662,
+    width: 304,
+    height: 156,
+    rotation: 0
+};
+
+export const mockStickyNote1 = {
+    type: "sticky_note",
+    shape: "square",
+    content: "<p>sticker1</p>",
+    style: {
+        fillColor: "light_yellow",
+        textAlign: "center",
+        textAlignVertical: "middle"
+    },
+    tagIds: [],
+    id: "3458764580516885999",
+    parentId: null,
+    origin: "center",
+    relativeTo: "canvas_center",
+    createdAt: "2024-02-27T23:01:04.686Z",
+    createdBy: "3458764575728178245",
+    modifiedAt: "2024-02-28T04:43:06.560Z",
+    modifiedBy: "3458764575728178245",
+    connectorIds: [],
+    x: -2712.8002239449133,
+    y: 1165.070165330662,
+    width: 212.93,
+    height: 243.96
+};
+
+export const mockStickyNote2 = {
+    type: "sticky_note",
+    shape: "square",
+    content: "<p>sticker2</p>",
+    style: {
+        fillColor: "yellow",
+        textAlign: "center",
+        textAlignVertical: "middle"
+    },
+    tagIds: [],
+    id: "3458764580516886689",
+    parentId: null,
+    origin: "center",
+    relativeTo: "canvas_center",
+    createdAt: "2024-02-27T23:02:58.420Z",
+    createdBy: "3458764575728178245",
+    modifiedAt: "2024-02-28T05:06:03.861Z",
+    modifiedBy: "3458764575728178245",
+    connectorIds: [],
+    x: -2712.8002239449133,
+    y: 1409.030165330662,
+    width: 212.93,
+    height: 243.96
+};


### PR DESCRIPTION
impl and tested:
- [x] #17 
- [x] #21 

in current groupingColor.test.ts:
given we are declaring global variables in the actual code, solution for testing for groupByColors() is to mock the function logic within the test file,
example output:
```
Map(4) {
    'Lightning Yellow' => Set(2) { '3458764580516886289', '3458764580530425719' },
    'Uncolored' => Set(1) { '3458764580530425796' },
    'Light Yellow' => Set(1) { '3458764580516885999' },
    'Yellow' => Set(1) { '3458764580516886689' }
}
```
