### PR TITLE
Update Interface for grouping

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -5,12 +5,13 @@ import { BoardNode } from "@mirohq/websdk-types";
 import "../src/assets/style.css";
 import { groupItems } from "./grouping";
 import GroupingList from "./components/groupingList";
+import { Cluster } from "./components/groupingList";
 import ActivityList from "./components/activityList"
 import Notifications from "./notifications";
 
 const App: React.FC = () => {
   // groupItems returns a JSON object
-  const [groups, setGroups] = React.useState<string>("");
+  const [groups, setGroups] = React.useState<{ [key: string]: Cluster }>({});
 
   const [messages, setMessages] = React.useState<string[]>([]);
 

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -20,3 +20,14 @@ img {
   max-width: 100%;
   height: auto;
 }
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}

--- a/src/components/groupingList.tsx
+++ b/src/components/groupingList.tsx
@@ -1,30 +1,88 @@
-import { BoardNode } from "@mirohq/websdk-types";
 import * as React from "react";
 
+interface GroupContent {
+  title: string;
+  content: any; // string[] or obj
+}
+
+export interface Cluster {
+  title: string;
+  content: { [key: string]: GroupContent } | string[];
+}
 interface Props {
-  groups: string;
+  groups: { [key: string]: Cluster };
   onUpdateGrouping: () => void;
 }
 
 const GroupingList: React.FC<Props> = ({ groups, onUpdateGrouping }) => {
+  const initialAnnouncement =
+    `There are ${Object.keys(groups).length} parts of the board. ` +
+    Object.keys(groups)
+      .map((clusterKey) => {
+        return `${clusterKey} is about ${groups[clusterKey].title}.`;
+      })
+      .join(" ");
+
   return (
-    <div
-      className="cs1 ce12"
-      role="region"
-      aria-roledescription="overview"
-      id="summary"
-      aria-labelledby="overviewheading"
-    >
-      <h1 id="overviewheading">Overview</h1>
+    <div className="cs1 ce12" role="region" aria-label="Overview">
+      <h1 aria-label="Overview">Overview</h1>
       <button
-        className="button button-primary button-medium"
+        className="update-overview-button button button-primary button-medium"
         type="button"
         onClick={onUpdateGrouping}
+        aria-label="Update Overview"
       >
         Update Overview
       </button>
-      {/* raw json for now to test the grouping out put */}
-      <pre>{groups}</pre>
+      <div className="sr-only" aria-live="polite">
+        {initialAnnouncement} To continue learning, use Control + Option + Shift
+        + Down arrow.
+      </div>
+      {Object.keys(groups).map((clusterKey) => (
+        <div
+          key={clusterKey}
+          role="group"
+          aria-label={`This group is about ${groups[clusterKey].title}`}
+        >
+          <h2>{groups[clusterKey].title}</h2>
+          {Array.isArray(groups[clusterKey].content) ? (
+            <div
+              role="group"
+              aria-label={`summary for group ${groups[clusterKey]}`}
+            >
+              {groups[clusterKey].content.map((item, index) => (
+                <p key={index} dangerouslySetInnerHTML={{ __html: item }} />
+              ))}
+            </div>
+          ) : (
+            Object.keys(groups[clusterKey].content).map((groupKey) => (
+              <div
+                key={groupKey}
+                role="group"
+                aria-label={`This group is about ${groups[clusterKey].content[groupKey].title}`}
+              >
+                <h3>{groups[clusterKey].content[groupKey].title}</h3>
+                {Array.isArray(groups[clusterKey].content[groupKey].content) ? (
+                  <div>
+                    {groups[clusterKey].content[groupKey].content.map(
+                      (item, index) => (
+                        <p
+                          key={index}
+                          dangerouslySetInnerHTML={{ __html: item }}
+                        />
+                      )
+                    )}
+                  </div>
+                ) : (
+                  <div>
+                    <p>{groups[clusterKey].content[groupKey].content}</p>
+                  </div>
+                )}
+              </div>
+            ))
+          )}
+        </div>
+      ))}
     </div>
   );
 };

--- a/src/components/groupingList.tsx
+++ b/src/components/groupingList.tsx
@@ -15,6 +15,7 @@ interface Props {
 }
 
 const GroupingList: React.FC<Props> = ({ groups, onUpdateGrouping }) => {
+  console.log(groups)
   const initialAnnouncement =
     `There are ${Object.keys(groups).length} parts of the board. ` +
     Object.keys(groups)
@@ -35,8 +36,7 @@ const GroupingList: React.FC<Props> = ({ groups, onUpdateGrouping }) => {
         Update Overview
       </button>
       <div className="sr-only" aria-live="polite">
-        {initialAnnouncement} To continue learning, use Control + Option + Shift
-        + Down arrow.
+        To continue learning, use Control + Option + Shift + Down arrow.
       </div>
       {Object.keys(groups).map((clusterKey) => (
         <div

--- a/src/grouping.tsx
+++ b/src/grouping.tsx
@@ -37,7 +37,8 @@ export async function groupItems() {
   processAllItems(jsonObject);
 
   // Conver to a string without modifying any properties and with an indentation of 2 spaces
-  return JSON.stringify(jsonObject, null, 2);
+  // return JSON.stringify(jsonObject, null, 2);
+  return jsonObject;
 }
 
 /**


### PR DESCRIPTION
current interface:
<img width="366" alt="image" src="https://github.com/cptbtptp01/ideation-accessibilty/assets/119706174/b696b1e1-e3f9-44ff-a6cb-e511197fdf95">

Issue:
- #7 
- #32 

Key updates:
- able to handle cluster with/without groups
- added accessibility related annotation to improve screen reader capability 
- update groupItems to return json obj, in order to provide dynamic output in groupingList.tsx

TODOs:
- coordinate with @koolgax99 to update title generated by gpt
- discuss with @koolgax99 and @z-q-ying about how to display each item's content (at element level, current displaying each item's content in a new line.)